### PR TITLE
Bugfix: re-allow "--program-key=xxxxx" as a command line arg.

### DIFF
--- a/program_admin/__init__.py
+++ b/program_admin/__init__.py
@@ -128,7 +128,10 @@ class ProgramAdmin:
                     continue
 
                 if isinstance(account, PythMappingAccount):
-                    actual_pair = (os.environ["PROGRAM_KEY"], str(account.public_key))
+                    actual_pair = (
+                        os.environ.get("PROGRAM_KEY") or str(self.program_key),
+                        str(account.public_key),
+                    )
                     test_mode = os.environ.get("TEST_MODE")
 
                     if test_mode or actual_pair in reference_pairs:


### PR DESCRIPTION
We accidentally assumed the program key is always passed as an environment variable.
Don't throw a KeyError when it's passed as a command line argument, but do allow the env var to take precedence.