### PR TITLE
Only sign with the keypairs that need to sign

### DIFF
--- a/program_admin/__init__.py
+++ b/program_admin/__init__.py
@@ -37,6 +37,7 @@ from program_admin.util import (
     PRICE_ACCOUNT_SIZE,
     PRODUCT_ACCOUNT_SIZE,
     compute_transaction_size,
+    get_actual_signers,
     recent_blockhash,
     sort_mapping_account_keys,
 )
@@ -156,27 +157,6 @@ class ProgramAdmin:
         signers: List[Keypair],
         dump_instructions: bool = False,
     ):
-        def get_actual_signers(
-            signers: List[Keypair], transaction: Transaction
-        ) -> List[Keypair]:
-            """
-            Given a list of keypairs and a transaction, returns the keypairs that actually need to sign the transaction,
-            i.e. those whose pubkey appears in at least one of the instructions as a signer.
-            """
-            actual_signers = []
-            for signer in signers:
-                instruction_has_signer = [
-                    any(
-                        signer.public_key == account.pubkey and account.is_signer
-                        for account in instruction.keys
-                    )
-                    for instruction in transaction.instructions
-                ]
-                if any(instruction_has_signer):
-                    actual_signers.append(signer)
-
-            return actual_signers
-
         if not instructions:
             return
 

--- a/program_admin/util.py
+++ b/program_admin/util.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
 
 from solana.blockhash import Blockhash
+from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment
@@ -107,3 +108,25 @@ def apply_overrides(
         else:
             overridden_permissions[key] = value
     return overridden_permissions
+
+
+def get_actual_signers(
+    signers: List[Keypair], transaction: Transaction
+) -> List[Keypair]:
+    """
+    Given a list of keypairs and a transaction, returns the keypairs that actually need to sign the transaction,
+    i.e. those whose pubkey appears in at least one of the instructions as a signer.
+    """
+    actual_signers = []
+    for signer in signers:
+        instruction_has_signer = [
+            any(
+                signer.public_key == account.pubkey and account.is_signer
+                for account in instruction.keys
+            )
+            for instruction in transaction.instructions
+        ]
+        if any(instruction_has_signer):
+            actual_signers.append(signer)
+
+    return actual_signers


### PR DESCRIPTION
Currently, all signers for a given list of instructions sign all the resulting transactions.
However, the list of instructions can get split in multiple transactions (when the list exceeds the maximum transaction size) and in that case we don't want all the signers to sign each transaction but only those that actually appear in the transaction.