### PR TITLE
Add min publishers to config file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
       - run: poetry run pytest
         env:
           TEST_MODE: "1"
+          DEV_MODE: "1"
   build-and-push-ecr:
     runs-on: ubuntu-latest
     needs: [run-tests]

--- a/program_admin/__init__.py
+++ b/program_admin/__init__.py
@@ -452,6 +452,21 @@ class ProgramAdmin:
             f"price_{reference_product['jump_symbol']}", key_dir=self.key_dir
         )
         price_account = self.get_price_account(price_keypair.public_key)
+
+        # Sync min publishers (if specified)
+        if reference_product["min_publishers"] is not None:
+            expected_min_publishers = reference_product["min_publishers"]
+            if price_account.data.min_publishers != expected_min_publishers:
+                instructions.append(
+                    pyth_program.set_minimum_publishers(
+                        self.program_key,
+                        funding_keypair.public_key,
+                        price_keypair.public_key,
+                        expected_min_publishers,
+                    )
+                )
+
+        # Synchronize publisher permissions
         current_publisher_keys = {
             comp.publisher_key for comp in price_account.data.price_components
         }

--- a/program_admin/parsing.py
+++ b/program_admin/parsing.py
@@ -241,10 +241,15 @@ def parse_products_json(file_path: Path) -> Dict[str, ReferenceProduct]:
         for product in json.load(stream):
             key = product["metadata"]["jump_symbol"]
 
+            min_publishers = None
+            if "min_publishers" in product["metadata"]:
+                min_publishers = product["metadata"]["min_publishers"]
+
             products[key] = {
                 "jump_symbol": product["metadata"]["jump_symbol"],
                 "exponent": product["metadata"]["price_exp"],
                 "metadata": product["attr_dict"],
+                "min_publishers": min_publishers,
             }
 
     return products

--- a/program_admin/types.py
+++ b/program_admin/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Literal, TypedDict, Union
+from typing import Dict, List, Literal, Optional, TypedDict, Union
 
 from solana.publickey import PublicKey
 
@@ -13,6 +13,9 @@ ReferenceProduct = TypedDict(
         "jump_symbol": str,
         "exponent": int,
         "metadata": Dict[str, str],
+        # This field is optional to enable backward compatibility with JSON files where it is not provided.
+        # If not provided, program admin will leave the on-chain value unchanged.
+        "min_publishers": Optional[int],
     },
 )
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -27,7 +27,12 @@ BTC_USD = {
         "generic_symbol": "BTCUSD",
         "description": "BTC/USD",
     },
-    "metadata": {"jump_id": "78876709", "jump_symbol": "BTCUSD", "price_exp": -8},
+    "metadata": {
+        "jump_id": "78876709",
+        "jump_symbol": "BTCUSD",
+        "price_exp": -8,
+        "min_publishers": 7,
+    },
 }
 AAPL_USD = {
     "account": "",
@@ -331,6 +336,19 @@ async def test_sync(
 
     assert price_accounts[0].data.price_components[0].publisher_key == random_publisher
     assert price_accounts[1].data.price_components[0].publisher_key == random_publisher
+
+    symbol_price_account_map = {}
+    for product_account in product_accounts:
+        symbol_price_account_map[product_account.data.metadata["symbol"]] = [
+            acc
+            for acc in price_accounts
+            if acc.public_key == product_account.data.first_price_account_key
+        ][0]
+
+    assert symbol_price_account_map["Crypto.BTC/USD"].data.min_publishers == 7
+    # Warning: this test hardcodes the default minimum number of publishers for the account.
+    # This default may change if you upgrade the oracle program.
+    assert symbol_price_account_map["Equity.US.AAPL/USD"].data.min_publishers == 20
 
     # Syncing again with generate_keys=False should succeed
     await sync_from_files(


### PR DESCRIPTION
Pretty straightforward change here. I left the field as optional to retain backward compatibility with older JSON files where the field isn't provided. If unspecified, the behavior is "don't change the on-chain field".