### PR TITLE
Update size of price accounts for v2

### DIFF
--- a/program_admin/util.py
+++ b/program_admin/util.py
@@ -16,7 +16,7 @@ from program_admin.types import (
 
 MAPPING_ACCOUNT_SIZE = 20536  # https://github.com/pyth-network/pyth-client/blob/b49f73afe32ce8685a3d05e32d8f3bb51909b061/program/src/oracle/oracle.h#L88
 MAPPING_ACCOUNT_PRODUCT_LIMIT = 640
-PRICE_ACCOUNT_SIZE = 3312
+PRICE_ACCOUNT_SIZE = 12576
 PRODUCT_ACCOUNT_SIZE = 512
 SOL_LAMPORTS = pow(10, 9)
 


### PR DESCRIPTION
This change should work with both old version of the oracle and the new version that's on main now.
I recommend we make it now since program-admin is used to create accounts in tests.