### PR TITLE
Initial support for authority permissions reference data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ ENV \
 RUN curl -sSL https://install.python-poetry.org | python
 ENV PATH="$POETRY_HOME/bin:$PATH"
 
+# Install Solana CLI
+RUN sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+ENV PATH=$PATH:/root/.local/share/solana/install/active_release/bin
+
+
 WORKDIR $APP_PATH
 COPY ./poetry.lock ./pyproject.toml ./
 COPY ./$APP_PACKAGE ./
@@ -73,7 +78,8 @@ FROM python:$PYTHON_VERSION as production
 ARG APP_NAME
 ARG APP_PATH
 
-# Install Solana CLI
+# Install Solana CLI, we redo this step because this Docker target
+# starts from scratch without the earlier Solana installation
 RUN sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
 ENV PATH=$PATH:/root/.local/share/solana/install/active_release/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,10 @@ FROM python:$PYTHON_VERSION as production
 ARG APP_NAME
 ARG APP_PATH
 
+# Install Solana CLI
+RUN sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+ENV PATH=$PATH:/root/.local/share/solana/install/active_release/bin
+
 ENV \
   PYTHONDONTWRITEBYTECODE=1 \
   PYTHONUNBUFFERED=1 \
@@ -89,11 +93,7 @@ COPY --from=build $APP_PATH/dist/*.whl ./
 COPY --from=build $APP_PATH/constraints.txt ./
 RUN pip install ./*.whl --requirement constraints.txt
 
-# Install Solana CLI
-RUN sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
-
 ENV APP_NAME=$APP_NAME
-ENV PATH=$PATH:/root/.local/share/solana/install/active_release/bin
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/program_admin/__init__.py
+++ b/program_admin/__init__.py
@@ -3,7 +3,7 @@ import os
 import sys
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Tuple, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from loguru import logger
 from solana import system_program
@@ -160,9 +160,11 @@ class ProgramAdmin:
             logger.debug(f"Found {len(self._price_accounts)} price account(s)")
 
             if self.authority_permission_account:
-                logger.debug(f"Found permission account: {self.authority_permission_account.data}")
+                logger.debug(
+                    f"Found permission account: {self.authority_permission_account.data}"
+                )
             else:
-                logger.debug(f"Authority permission account not found")
+                logger.debug("Authority permission account not found")
 
     async def send_transaction(
         self, instructions: List[TransactionInstruction], signers: List[Keypair]
@@ -289,16 +291,25 @@ class ProgramAdmin:
 
         if ref_authority_permissions:
             # Sync authority permissions
-            (authority_instructions, authority_signers) = await self.sync_authority_permissions_instructions(ref_authority_permissions)
+            (
+                authority_instructions,
+                authority_signers,
+            ) = await self.sync_authority_permissions_instructions(
+                ref_authority_permissions
+            )
 
             if authority_instructions:
                 instructions.extend(authority_instructions)
 
                 if send_transactions:
-                    await self.send_transaction(authority_instructions, authority_signers)
+                    await self.send_transaction(
+                        authority_instructions, authority_signers
+                    )
 
         else:
-            logger.debug("Reference data for authority permissions is not defined, skipping...")
+            logger.debug(
+                "Reference data for authority permissions is not defined, skipping..."
+            )
 
         return instructions
 
@@ -541,15 +552,22 @@ class ProgramAdmin:
     ) -> Tuple[List[TransactionInstruction], List[Keypair]]:
         instructions = []
         signers = []
-        if (not self.authority_permission_account or
-            not self.authority_permission_account.matches_reference_data(reference_authority_permissions)):
-            upgrade_authority_keypair = load_keypair("upgrade_authority", key_dir=self.key_dir)
+        if (
+            not self.authority_permission_account
+            or not self.authority_permission_account.matches_reference_data(
+                reference_authority_permissions
+            )
+        ):
+            upgrade_authority_keypair = load_keypair(
+                "upgrade_authority", key_dir=self.key_dir
+            )
 
             logger.debug("Building pyth_program.upd_permissions instruction")
-            instruction = pyth_program.upd_permissions(self.program_key,
-                                                       upgrade_authority_keypair.public_key,
-                                                       reference_authority_permissions,
-                                                       )
+            instruction = pyth_program.upd_permissions(
+                self.program_key,
+                upgrade_authority_keypair.public_key,
+                reference_authority_permissions,
+            )
             instructions = [instruction]
             signers = [upgrade_authority_keypair]
         else:

--- a/program_admin/cli.py
+++ b/program_admin/cli.py
@@ -12,6 +12,7 @@ from solana.publickey import PublicKey
 from program_admin import ProgramAdmin, instructions
 from program_admin.keys import load_keypair, restore_symlink
 from program_admin.parsing import (
+    parse_authority_permissions_json,
     parse_permissions_with_overrides,
     parse_products_json,
     parse_publishers_json,
@@ -388,6 +389,9 @@ def restore_links(network, rpc_endpoint, program_key, keys, products, commitment
     "--permissions", help="Path to reference permissions file", envvar="PERMISSIONS"
 )
 @click.option(
+    "--authority-permissions", help="Path to reference authority permissions file", envvar="AUTHORITY_PERMISSIONS"
+)
+@click.option(
     "--overrides", help="Path to reference overrides file", envvar="OVERRIDES"
 )
 @click.option(
@@ -416,6 +420,7 @@ def sync(
     products,
     publishers,
     permissions,
+    authority_permissions,
     overrides,
     commitment,
     send_transactions,
@@ -434,12 +439,17 @@ def sync(
     ref_permissions = parse_permissions_with_overrides(
         Path(permissions), Path(overrides), network
     )
+    ref_authority_permissions = None
 
+    if authority_permissions:
+        ref_authority_permissions = parse_authority_permissions_json(Path(authority_permissions))
+    
     asyncio.run(
         program_admin.sync(
             ref_products=ref_products,
             ref_publishers=ref_publishers,
             ref_permissions=ref_permissions,
+            ref_authority_permissions=ref_authority_permissions,
             send_transactions=(send_transactions == "true"),
             generate_keys=(generate_keys == "true"),
         )

--- a/program_admin/cli.py
+++ b/program_admin/cli.py
@@ -389,7 +389,9 @@ def restore_links(network, rpc_endpoint, program_key, keys, products, commitment
     "--permissions", help="Path to reference permissions file", envvar="PERMISSIONS"
 )
 @click.option(
-    "--authority-permissions", help="Path to reference authority permissions file", envvar="AUTHORITY_PERMISSIONS"
+    "--authority-permissions",
+    help="Path to reference authority permissions file",
+    envvar="AUTHORITY_PERMISSIONS",
 )
 @click.option(
     "--overrides", help="Path to reference overrides file", envvar="OVERRIDES"
@@ -442,8 +444,10 @@ def sync(
     ref_authority_permissions = None
 
     if authority_permissions:
-        ref_authority_permissions = parse_authority_permissions_json(Path(authority_permissions))
-    
+        ref_authority_permissions = parse_authority_permissions_json(
+            Path(authority_permissions)
+        )
+
     asyncio.run(
         program_admin.sync(
             ref_products=ref_products,

--- a/program_admin/instructions.py
+++ b/program_admin/instructions.py
@@ -2,12 +2,11 @@ from typing import Dict
 
 from construct import Bytes, Int32sl, Int32ul, Struct
 from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction
 from solana.system_program import SYS_PROGRAM_ID
-
-from program_admin.util import encode_product_metadata
+from solana.transaction import AccountMeta, TransactionInstruction
 
 from program_admin.types import ReferenceAuthorityPermissions
+from program_admin.util import encode_product_metadata
 
 # TODO: Implement add_mapping instruction
 
@@ -25,10 +24,11 @@ COMMAND_UPD_PERMISSIONS = 17
 PRICE_TYPE_PRICE = 1
 PROGRAM_VERSION = 2
 
-AUTHORITY_PERMISSIONS_PDA_SEED = b"permissions";
+AUTHORITY_PERMISSIONS_PDA_SEED = b"permissions"
 
 # NOTE(2023-07-11): currently the loader's address is not part of our version of solana-py
 BPF_UPGRADEABLE_LOADER_ID = "BPFLoaderUpgradeab1e11111111111111111111111"
+
 
 def init_mapping(
     program_key: PublicKey, funding_key: PublicKey, mapping_key: PublicKey
@@ -265,11 +265,12 @@ def toggle_publisher(
         program_id=program_key,
     )
 
+
 def upd_permissions(
-        program_key: PublicKey,
-        upgrade_authority: PublicKey,
-        refdata: ReferenceAuthorityPermissions,
-        ) -> TransactionInstruction:
+    program_key: PublicKey,
+    upgrade_authority: PublicKey,
+    refdata: ReferenceAuthorityPermissions,
+) -> TransactionInstruction:
     """
     Pyth program upd_permissions instruction. Sets contents of the
     permission account which allows us to name various authorities:
@@ -292,16 +293,17 @@ def upd_permissions(
         "master_authority" / Bytes(32),
         "data_curation_authority" / Bytes(32),
         "security_authority" / Bytes(32),
-        )
+    )
 
     ix_data = ix_data_layout.build(
-        dict(version=PROGRAM_VERSION,
-             command=COMMAND_UPD_PERMISSIONS,
-             master_authority=bytes(refdata["master_authority"]),
-             data_curation_authority=bytes(refdata["data_curation_authority"]),
-             security_authority=bytes(refdata["security_authority"]),
+        dict(
+            version=PROGRAM_VERSION,
+            command=COMMAND_UPD_PERMISSIONS,
+            master_authority=bytes(refdata["master_authority"]),
+            data_curation_authority=bytes(refdata["data_curation_authority"]),
+            security_authority=bytes(refdata["security_authority"]),
         )
-        )
+    )
 
     [permissions_account, _bump] = PublicKey.find_program_address(
         [AUTHORITY_PERMISSIONS_PDA_SEED],
@@ -319,10 +321,12 @@ def upd_permissions(
     return TransactionInstruction(
         data=ix_data,
         keys=[
-                AccountMeta(pubkey=upgrade_authority, is_signer=True, is_writable=True),
-                AccountMeta(pubkey=oracle_program_data_key, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=permissions_account, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),
-            ],
+            AccountMeta(pubkey=upgrade_authority, is_signer=True, is_writable=True),
+            AccountMeta(
+                pubkey=oracle_program_data_key, is_signer=False, is_writable=False
+            ),
+            AccountMeta(pubkey=permissions_account, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),
+        ],
         program_id=program_key,
-        )
+    )

--- a/program_admin/parsing.py
+++ b/program_admin/parsing.py
@@ -21,15 +21,13 @@ from program_admin.types import (
     PythMappingAccount,
     PythPriceAccount,
     PythProductAccount,
-    ReferenceOverrides,
     ReferenceAuthorityPermissions,
+    ReferenceOverrides,
     ReferencePermissions,
     ReferenceProduct,
     ReferencePublishers,
 )
 from program_admin.util import apply_overrides
-
-from loguru import logger
 
 MAGIC_NUMBER = "0xa1b2c3d4"
 VERSION = 2
@@ -159,9 +157,9 @@ def parse_price_data(data: bytes) -> PriceData:
 
 
 def parse_authority_permission_data(data: bytes) -> AuthorityPermissionData:
-    # Start by offsetting the header, currently 4 * u32 = 16 bytes 
-    data_with_current_offset = data[16:] 
-    
+    # Start by offsetting the header, currently 4 * u32 = 16 bytes
+    data_with_current_offset = data[16:]
+
     master_authority = PublicKey(data_with_current_offset[:32])
 
     # Continue adjusting offset after parsing each chunk of the data.
@@ -169,12 +167,15 @@ def parse_authority_permission_data(data: bytes) -> AuthorityPermissionData:
 
     data_curation_authority = PublicKey(data_with_current_offset[:32])
     data_with_current_offset = data_with_current_offset[32:]
-    
+
     security_authority = PublicKey(data_with_current_offset[:32])
 
-    return AuthorityPermissionData(master_authority, data_curation_authority, security_authority)
+    return AuthorityPermissionData(
+        master_authority, data_curation_authority, security_authority
+    )
 
 
+# pylint: disable=too-many-return-statements
 def parse_data(data: bytes) -> Optional[AccountData]:
     magic_number = hex(Int32ul.parse(data[0:]))
     version = Int32ul.parse(data[4:])
@@ -196,7 +197,7 @@ def parse_data(data: bytes) -> Optional[AccountData]:
         return parse_authority_permission_data(data)
     if data_type == ACCOUNT_TYPE_TEST:
         return None
-        
+
     raise RuntimeError(f"Invalid account type: {data_type}")
 
 
@@ -240,9 +241,11 @@ def parse_publishers_json(file_path: Path) -> ReferencePublishers:
             "names": names,
         }
 
+
 def parse_permissions_json(file_path: Path) -> ReferencePermissions:
     with file_path.open() as stream:
         return json.load(stream)
+
 
 def parse_authority_permissions_json(file_path: Path) -> ReferenceAuthorityPermissions:
     with file_path.open() as stream:
@@ -251,8 +254,10 @@ def parse_authority_permissions_json(file_path: Path) -> ReferenceAuthorityPermi
 
         return ReferenceAuthorityPermissions(
             master_authority=PublicKey(str(perm_dict["master_authority"])),
-            data_curation_authority=PublicKey(str(perm_dict["data_curation_authority"])),
-            security_authority=PublicKey(str(perm_dict["security_authority"]))
+            data_curation_authority=PublicKey(
+                str(perm_dict["data_curation_authority"])
+            ),
+            security_authority=PublicKey(str(perm_dict["security_authority"])),
         )
 
 

--- a/program_admin/types.py
+++ b/program_admin/types.py
@@ -35,6 +35,7 @@ class ReferenceAuthorityPermissions(TypedDict):
     data_curation_authority: PublicKey
     security_authority: PublicKey
 
+
 # network -> symbol -> enabled / disabled. Default is no change to permissions.
 ReferenceOverrides = Dict[str, Dict[str, bool]]
 
@@ -114,6 +115,7 @@ class PriceData:
     def __str__(self) -> str:
         return f"PriceData(product_key={str(self.product_account_key)[0:5]}...)"
 
+
 @dataclass
 class AuthorityPermissionData:
     master_authority: PublicKey
@@ -154,6 +156,7 @@ class PythProductAccount(PythAccount):
 class PythPriceAccount(PythAccount):
     data: PriceData
 
+
 @dataclass
 class PythAuthorityPermissionAccount(PythAccount):
     """
@@ -164,9 +167,12 @@ class PythAuthorityPermissionAccount(PythAccount):
     account is responsible for global oracle administration
     authorities.
     """
+
     data: AuthorityPermissionData
 
     def matches_reference_data(self, refdata: ReferenceAuthorityPermissions) -> bool:
-        return (refdata["master_authority"] == self.data.master_authority and
-                refdata["data_curation_authority"] == self.data.data_curation_authority and
-                refdata["security_authority"] == self.data.security_authority)
+        return (
+            refdata["master_authority"] == self.data.master_authority
+            and refdata["data_curation_authority"] == self.data.data_curation_authority
+            and refdata["security_authority"] == self.data.security_authority
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ known_local_folder = ["program_admin"]
 authors = ["Thomaz <thomaz@pyth.network>"]
 description = "Syncs products and publishers of the Pyth program"
 name = "program-admin"
-version = "0.1.0"
+version = "0.1.1"
 
 [tool.poetry.dependencies]
 click = "^8.1.0"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
@@ -71,13 +70,13 @@ MASTER_AUTHORITY = "23CGbZq2AAzZcHk1vVBs9Zq4AkNJhjxRbjMiCFTy8vJP"
 DATA_CURATION_AUTHORITY = "33CGbZq2AAzZcHk1vVBs9Zq4AkNJhjxRbjMiCFTy8vJP"
 SECURITY_AUTHORITY = "43CGbZq2AAzZcHk1vVBs9Zq4AkNJhjxRbjMiCFTy8vJP"
 
+
 @pytest.fixture
 def set_test_env_var():
     """
     Sets an env required for program-admin sync() testing
     """
     os.environ["TEST_MODE"] = "1"
-
 
 
 @pytest.fixture
@@ -151,24 +150,22 @@ def permissions2_json():
 
         yield jsonfile.name
 
+
 @pytest.fixture
 def authority_permissions_json():
     with NamedTemporaryFile() as jsonfile:
         value = {
-                    "master_authority": MASTER_AUTHORITY,
-                    "data_curation_authority": DATA_CURATION_AUTHORITY,
-                    "security_authority": SECURITY_AUTHORITY,
-                }
+            "master_authority": MASTER_AUTHORITY,
+            "data_curation_authority": DATA_CURATION_AUTHORITY,
+            "security_authority": SECURITY_AUTHORITY,
+        }
 
         LOGGER.debug(f"Writing authority permissions JSON:\n{value}")
-        jsonfile.write(
-            json.dumps(
-                value
-            ).encode()
-        )
+        jsonfile.write(json.dumps(value).encode())
         jsonfile.flush()
 
         yield jsonfile.name
+
 
 @pytest.fixture
 def empty_overrides_json():
@@ -238,6 +235,7 @@ async def pyth_keypair(key_dir, validator):
 
     yield f"{key_dir}/funding.json"
 
+
 @pytest.fixture
 async def upgrade_authority_keypair(key_dir, validator):
     keypair_path = f"{key_dir}/upgrade_authority.json"
@@ -276,7 +274,8 @@ async def upgrade_authority_keypair(key_dir, validator):
     if stderr:
         print(f"[stderr]\n{stderr.decode()}")
 
-    yield keypair_path 
+    yield keypair_path
+
 
 # pylint: disable=redefined-outer-name,unused-argument
 @pytest.fixture
@@ -506,7 +505,9 @@ async def sync_from_files(
     ref_permissions = parse_permissions_with_overrides(
         Path(permissions_path), Path(overrides_path), network
     )
-    ref_authority_permissions = parse_authority_permissions_json(Path(authority_permissions_path))
+    ref_authority_permissions = parse_authority_permissions_json(
+        Path(authority_permissions_path)
+    )
 
     return await program_admin.sync(
         ref_products,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -160,7 +160,7 @@ def authority_permissions_json():
             "security_authority": SECURITY_AUTHORITY,
         }
 
-        LOGGER.debug(f"Writing authority permissions JSON:\n{value}")
+        LOGGER.debug("Writing authority permissions JSON:\n%s", value)
         jsonfile.write(json.dumps(value).encode())
         jsonfile.flush()
 


### PR DESCRIPTION
# Motivation
As a prerequisite for price account resizing, we need to initialize an authority permissions PDA in the oracle program. This change adds support for authority permissions reference data and setting the PDA's contents from program-admin.

The authority changes are made by a new `upgrade_authority` keypair, which must have authority over the oracle program.

On the CLI, this is reflected with an optional `--reference-authority-permissions <json file>` argument. When this option is undefined, no permissions updates take place. This will be useful for environments that decide authority permissions via governance. Regardless of this option, program-admin always reports current authority permission values found on-chain.

# Summary of changes
* Add types for on-chain authority  permissions state and a dedicated reference data file. This includes a method for comparing reference data with authority permissions found on chain. 
* Add parsing functions for authority permissions and the reference data 
* Add helper method for constructing the `upd_permissions` oracle instruction
* Misc: Dockerfile: Move Solana installation before sources are copied into the container. This makes iteration in development quicker. Solana is also made available in the `development` Docker target, to enable running unit tests inside the container.

# Testing
* I verified that the new functionality works well within the `integration` Tilt environment (I developed the change in situ, inside the program-admin submodule)
* Tests continue to pass and include mock authority keys and verification of their values in `test_sync`

# Review Highlights
* The on-chain authority permission account is very similar to the existing `permissions` concept in program-admin (the per-publisher permissions to contribute to a price). I decided to call the new functionality "authority permissions". It is important that the purpose of "authority permissions" and "permissions" is clearly separated.