### PR TITLE
Parallelize account and publisher sync

### DIFF
--- a/program_admin/__init__.py
+++ b/program_admin/__init__.py
@@ -283,7 +283,8 @@ class ProgramAdmin:
                 if send_transactions:
                     transactions.append(
                         asyncio.create_task(
-                            self.send_transaction(product_instructions, product_keypairs)
+                            self.send_transaction(
+                                product_instructions, product_keypairs)
                         )
                     )
 
@@ -311,7 +312,9 @@ class ProgramAdmin:
                 if send_transactions:
                     transactions.append(
                         asyncio.create_task(
-                            self.send_transaction(price_instructions, price_keypairs)
+                            self.send_transaction(
+                                price_instructions, price_keypairs
+                            )
                         )
                     )
 

--- a/program_admin/__init__.py
+++ b/program_admin/__init__.py
@@ -1,4 +1,3 @@
-from asyncio import Future
 import asyncio
 import json
 import os
@@ -282,7 +281,9 @@ class ProgramAdmin:
 
                 instructions.extend(product_instructions)
                 if send_transactions:
-                    transactions.append(self.send_transaction(product_instructions, product_keypairs))
+                    transactions.append(
+                        self.send_transaction(product_instructions, product_keypairs)
+                    )
 
         await asyncio.gather(*transactions)
 
@@ -306,7 +307,9 @@ class ProgramAdmin:
             if price_instructions:
                 instructions.extend(price_instructions)
                 if send_transactions:
-                    transactions.append(self.send_transaction(price_instructions, price_keypairs))
+                    transactions.append(
+                        self.send_transaction(price_instructions, price_keypairs)
+                    )
 
         await asyncio.gather(*transactions)
 

--- a/program_admin/__init__.py
+++ b/program_admin/__init__.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 from pathlib import Path
-from typing import Any, Coroutine, Dict, List, Literal, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple
 
 from loguru import logger
 from solana import system_program
@@ -284,7 +284,8 @@ class ProgramAdmin:
                     transactions.append(
                         asyncio.create_task(
                             self.send_transaction(
-                                product_instructions, product_keypairs)
+                                product_instructions, product_keypairs
+                            )
                         )
                     )
 
@@ -312,9 +313,7 @@ class ProgramAdmin:
                 if send_transactions:
                     transactions.append(
                         asyncio.create_task(
-                            self.send_transaction(
-                                price_instructions, price_keypairs
-                            )
+                            self.send_transaction(price_instructions, price_keypairs)
                         )
                     )
 

--- a/program_admin/__init__.py
+++ b/program_admin/__init__.py
@@ -261,7 +261,7 @@ class ProgramAdmin:
 
         # Sync product/price accounts
 
-        transactions: list[Coroutine[Any, Any, None]] = []
+        transactions: List[asyncio.Task[None]] = []
 
         product_updates: bool = False
 
@@ -282,7 +282,9 @@ class ProgramAdmin:
                 instructions.extend(product_instructions)
                 if send_transactions:
                     transactions.append(
-                        self.send_transaction(product_instructions, product_keypairs)
+                        asyncio.create_task(
+                            self.send_transaction(product_instructions, product_keypairs)
+                        )
                     )
 
         await asyncio.gather(*transactions)
@@ -308,7 +310,9 @@ class ProgramAdmin:
                 instructions.extend(price_instructions)
                 if send_transactions:
                     transactions.append(
-                        self.send_transaction(price_instructions, price_keypairs)
+                        asyncio.create_task(
+                            self.send_transaction(price_instructions, price_keypairs)
+                        )
                     )
 
         await asyncio.gather(*transactions)


### PR DESCRIPTION
In my tests with 2 validator and 2 publisher nodes, this reduced the program-admin execution time when bringing up Blockmark from 1400 sec to 140 sec. I'll leave it running for a while before merging, just to check that there are no untoward effects.